### PR TITLE
Optimise mem usage, disallowing random ref order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pycoverm"
 version = "0.4.0"
 authors = ["Antonio Camargo <antoniop.camargo@gmail.com>"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 homepage = "https://github.com/apcamargo/pycoverm"
 keywords = ["bioinformatics"]
@@ -13,7 +13,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 coverm = "0.6.0"
-indexmap = "1.6.2"
 ndarray = "0.13.1"
 numpy = "0.12.1"
 pyo3 = { version = "0.12.4", features = ["extension-module"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,7 @@ fn default_return_value(py: Python, n_files: usize) -> (Py<PyAny>, Py<PyAny>) {
 fn index_map(headers: &[String], names: &HashSet<&str>) -> Vec<u32> {
     // Make sure there are no names in names which are not in headers.
     let mut n_seen: usize = 0;
-    let mut result = vec![u32::MAX; names.len()];
+    let mut result = vec![u32::MAX; headers.len()];
     let mut new_index: u32 = 0;
     for (i, header) in headers.iter().enumerate() {
         if names.contains(&header.as_str()) {
@@ -233,7 +233,7 @@ fn index_map(headers: &[String], names: &HashSet<&str>) -> Vec<u32> {
         }
     }
     if n_seen != names.len() {
-        panic!("Some names in `names` were not found in headers")
+        panic!("Some names in `contig_set` were not found in BAM headers")
     }
     result
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,7 @@ use coverm::{
     bam_generator::*, contig::*, coverage_takers::*, mosdepth_genome_coverage_estimators::*,
     FlagFilter,
 };
-use indexmap::IndexMap;
-use ndarray::Array2;
+use ndarray::Array;
 use numpy::convert::ToPyArray;
 use pyo3::{prelude::*, wrap_pyfunction};
 use rust_htslib::{bam, bam::Read};
@@ -44,15 +43,17 @@ struct EstimatorsAndTaker {
 fn is_bam_sorted(bam_file: &str) -> PyResult<bool> {
     let bam = bam::Reader::from_path(bam_file).unwrap();
     let bytes = &bam::Header::from_template(bam.header()).to_bytes();
-    Ok(bytes.windows(13).any(|window| {window == b"SO:coordinate"}))
+    Ok(bytes.windows(13).any(|window| window == b"SO:coordinate"))
 }
 
 /// get_coverages_from_bam(bam_list, contig_end_exclusion=75, min_identity=0.97,
 /// trim_lower=0.0, trim_upper=0.0, contig_list=None, threads=1)
 /// --
 ///
-/// Computes contig mean coverages from sorted BAM files. Trimmed means will be
-/// computed if `trim_min` and/or `trim_max` are set to values greater than 0.
+/// Computes contig mean coverages from sorted BAM files. All BAM files must be
+/// mapped to the same reference.
+/// Trimmed means will be computed if `trim_min` and/or `trim_max` are set to
+/// values greater than 0.
 ///
 /// Parameters
 /// ----------
@@ -122,12 +123,9 @@ fn get_coverages_from_bam(
         contig_end_exclusion,
     )];
     let taker = CoverageTakerType::new_cached_single_float_coverage_taker(estimators.len());
-    let mut estimators_and_taker = EstimatorsAndTaker {
-        estimators: estimators,
-        taker: taker,
-    };
+    let mut estimators_and_taker = EstimatorsAndTaker { estimators, taker };
     let bam_readers = generate_filtered_bam_readers_from_bam_files(
-        bam_list,
+        bam_list.clone(),
         filter_params.flag_filters.clone(),
         filter_params.min_aligned_length_single,
         filter_params.min_percent_identity_single,
@@ -136,6 +134,33 @@ fn get_coverages_from_bam(
         filter_params.min_percent_identity_pair,
         filter_params.min_aligned_percent_pair,
     );
+
+    // Get the headers from the first file, and verify all files have the same header.
+    let mut headers: Vec<String> = match verify_same_bam_headers(&bam_list, &bam_readers) {
+        // If no files: Return early with empty list
+        None => {
+            assert!(bam_list.is_empty());
+            return default_return_value(py, 0);
+        }
+        // Else: Copy the headers, since they must be moved into `contig_coverage` below.
+        Some((_, headers)) => headers
+            .iter()
+            .map(|&v| String::from_utf8_lossy(v).into_owned())
+            .collect(),
+    };
+
+    // The map lets us filter out contigs not in the contig map.
+    let map = contig_set.map(|names| index_map(&headers, &names));
+    if let Some(ref map) = map {
+        // If the empty set is passed, return early with empty list
+        if map.is_empty() {
+            return default_return_value(py, bam_list.len());
+        }
+        let mut itr = map.iter();
+        headers.retain(|_| *itr.next().unwrap() != u32::MAX)
+    }
+
+    // Compute coverage
     contig_coverage(
         bam_readers,
         &mut estimators_and_taker.taker,
@@ -145,68 +170,93 @@ fn get_coverages_from_bam(
         threads,
     );
 
-    let mut contig_coverages = IndexMap::new();
+    // Fill in matrix
+    let mut matrix = Array::zeros((headers.len(), bam_list.len()));
     match &estimators_and_taker.taker {
         CoverageTakerType::CachedSingleFloatCoverageTaker {
             stoit_names: _,
-            entry_names,
+            entry_names: _,
             coverages,
             current_stoit_index: _,
             current_entry_index: _,
             num_coverages: _,
         } => {
-            for input_bam in coverages {
+            for (col, input_bam) in coverages.iter().enumerate() {
                 for coverage_entry in input_bam {
-                    if let Some(contig_name) = &entry_names[coverage_entry.entry_index] {
-                        let contig_coverage_vector =
-                            contig_coverages.entry(contig_name).or_insert(vec![]);
-                        contig_coverage_vector.push(coverage_entry.coverage);
+                    let mut row = coverage_entry.entry_index;
+                    if let Some(ref map) = map {
+                        let i = map[coverage_entry.entry_index];
+                        if i == u32::MAX {
+                            continue;
+                        } else {
+                            row = i as usize
+                        }
                     }
+                    matrix[[row, col]] = coverage_entry.coverage
                 }
             }
         }
         _ => unreachable!(),
     }
+    (
+        matrix
+            .to_pyarray(Python::acquire_gil().python())
+            .into_py(py),
+        headers.into_py(py),
+    )
+}
 
-    // If `contig_set` is `None`, the coverage of every contig found within the input BAM files
-    // will be stored. If `contig_set` is a set containing contig names, only the coverages of those
-    // contigs will be stored.
+fn default_return_value(py: Python, n_files: usize) -> (Py<PyAny>, Py<PyAny>) {
+    (
+        Array::from_elem((0, n_files), 0f32)
+            .to_pyarray(Python::acquire_gil().python())
+            .into_py(py),
+        Vec::<String>::new().into_py(py),
+    )
+}
 
-    let (filter_contigs, contig_set) = match contig_set {
-        Some(_) => (true, contig_set.unwrap()),
-        None => (false, HashSet::new()),
-    };
-
-    let mut coverage_vector: std::vec::Vec<f32> = Vec::new();
-    let mut contig_names_vector = Vec::new();
-
-    if filter_contigs {
-        for (contig_name, contig_coverage_vector) in contig_coverages.iter() {
-            if contig_set.contains(contig_name.as_str()) {
-                coverage_vector.extend(contig_coverage_vector);
-                contig_names_vector.push(*contig_name);
-            }
-        }
-    } else {
-        for (contig_name, contig_coverage_vector) in contig_coverages.iter() {
-            coverage_vector.extend(contig_coverage_vector);
-            contig_names_vector.push(*contig_name);
+/// Map from index of original reference to index in new reference, only
+/// keeping those headers that are in names.
+/// Headers not in names will map to u32::MAX.
+/// Hence, header ["a", "b", "c"] and names ["c", "a"] will give
+/// [0, u32::MAX, 1]
+fn index_map(headers: &[String], names: &HashSet<&str>) -> Vec<u32> {
+    // Make sure there are no names in names which are not in headers.
+    let mut n_seen: usize = 0;
+    let mut result = vec![u32::MAX; names.len()];
+    let mut new_index: u32 = 0;
+    for (i, header) in headers.iter().enumerate() {
+        if names.contains(&header.as_str()) {
+            result[i] = new_index;
+            new_index += 1;
+            n_seen += 1
         }
     }
+    if n_seen != names.len() {
+        panic!("Some names in `names` were not found in headers")
+    }
+    result
+}
 
-    let coverage_vector = Array2::from_shape_vec(
-        (
-            contig_names_vector.len(),
-            coverage_vector.len() / contig_names_vector.len(),
-        ),
-        coverage_vector,
-    )
-    .unwrap()
-    .to_pyarray(Python::acquire_gil().python())
-    .into_py(py);
-    let contig_names_vector = contig_names_vector.into_py(py);
-
-    (contig_names_vector, coverage_vector)
+fn verify_same_bam_headers<'a, 'b>(
+    bam_paths: &[&'a str],
+    readers: &'b [FilteredBamReader],
+) -> Option<(&'a str, Vec<&'b [u8]>)> {
+    bam_paths
+        .iter()
+        .zip(readers.iter())
+        .fold(None, |state, (filename, reader)| {
+            let new_names = reader.header().target_names();
+            if let Some((old_filename, old_names)) = state {
+                if old_names != new_names {
+                    panic!(
+                        "Headers of BAM file {} does not match those of BAM file {}.",
+                        old_filename, filename
+                    )
+                }
+            }
+            Some((*filename, new_names))
+        })
 }
 
 #[pymodule]


### PR DESCRIPTION
Currently, pycoverm is not particularly memory efficient. It keeps coverages in an name=>Vec<f32> IndexMap, then creates a matrix and fills the matrxi from the map.
This allows the order of reference sequences in the BAM files to be in different order, but it consumes a lot of memory. Further, it's not very common to have a situation where BAM files are mapped to the exact same set of references, but in a different order, as BAM reference order is deterministic, and reflects the order of the reference FASTA file.

This commit checks that all BAM files have the same headers in the same order. It then computes an old_refindex => new_refindex map, which can be stored as a single Vec<u32>. The coverage matrix can then be preallocated and filled in. This approach is nearly perfectly memory efficient.

The only remaining issue is that the headers might take up a lot of memory, which is unnecessary in the case that the users already know the headers. This might seem trivial, but if there are 10 million sequences that each has to be heap allocated, it can take some time. A solution to this, which I employ in Vamb, is to pass a hash of the headers to the coverage computation. The headers can then be verified without consuming any memory.