### PR TITLE
Fix wrong order of return values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,19 +199,19 @@ fn get_coverages_from_bam(
         _ => unreachable!(),
     }
     (
+        headers.into_py(py),
         matrix
             .to_pyarray(Python::acquire_gil().python())
             .into_py(py),
-        headers.into_py(py),
     )
 }
 
 fn default_return_value(py: Python, n_files: usize) -> (Py<PyAny>, Py<PyAny>) {
     (
+        Vec::<String>::new().into_py(py),
         Array::from_elem((0, n_files), 0f32)
             .to_pyarray(Python::acquire_gil().python())
             .into_py(py),
-        Vec::<String>::new().into_py(py),
     )
 }
 


### PR DESCRIPTION
In a previous commit, the order of (headers, matrix) was unintentionally swapped to (matrix, headers), contrary to the docstring. Fix this bug.

Side note: I can't _believe_ I put in such an obvious bug. Sorry for the trouble.